### PR TITLE
Issue pg-irc/pathways-frontend#841 extract bookmark strings

### DIFF
--- a/jsx_strings/jsx_strings.pot
+++ b/jsx_strings/jsx_strings.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2019-09-20 11:11-0700\n"
+"POT-Creation-Date: 2019-12-27 13:08-0800\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -11,28 +11,32 @@ msgstr ""
 msgid "ABOUT THE APP"
 msgstr "ABOUT THE APP"
 
+#: lib/components/organizations/organization_detail_component.js:33
+msgid "About"
+msgstr "About"
+
 #: lib/components/about/about_component.js:21
 #: lib/components/header_menu/header_menu_component.js:49
 msgid "About Arrival Advisor"
 msgstr "About Arrival Advisor"
 
-#: lib/components/services/service_list_item_component.js:37
-msgid "Address:"
-msgstr "Address:"
+#: lib/components/addresses/addresses_component.js:14
+msgid "Address"
+msgstr "Address"
 
 #: lib/components/error_screens/ErrorScreenSwitcherComponent.js:25
 msgid "An error occurred"
-msgstr ""
+msgstr "An error occurred"
 
 #: lib/components/onboarding/onboarding_component.js:33
 msgid "Answer a few optional questions to get tailored recommendations for your needs."
 msgstr "Answer a few optional questions to get tailored recommendations for your needs."
 
-#: lib/components/recommended_topics/call_to_action.js:46
+#: lib/components/recommended_topics/call_to_action.js:43
 msgid "Answer a few questions about your situation to get personalized recommendations of topics and services to help you settle in British Columbia."
 msgstr "Answer a few questions about your situation to get personalized recommendations of topics and services to help you settle in British Columbia."
 
-#: lib/components/recommended_topics/call_to_action.js:55
+#: lib/components/recommended_topics/call_to_action.js:52
 msgid "Answer questions"
 msgstr "Answer questions"
 
@@ -52,11 +56,11 @@ msgstr "Arrival Advisor is your go-to guide to getting settled in your new commu
 msgid "Arrival Advisor respects and maintains the privacy and anonymity of its users. Users do not need to provide personal information in order to use the app. The questionnaire is designed to assist in personalizing services and resources required by the user, and answers are only saved to enhance the usability of the app over time. Users of the Arrival Advisor app do so at their own discretion. The answers you provide will be used for the operation of this tool to provide you with guidance on resources and services that can help you adjust to life in Canada. Users cannot be identified by their answers to the questionnaire. The information is not used by Immigration, Refugees and Citizenship Canada for any other purpose and is not used for any immigration decision making."
 msgstr "Arrival Advisor respects and maintains the privacy and anonymity of its users. Users do not need to provide personal information in order to use the app. The questionnaire is designed to assist in personalizing services and resources required by the user, and answers are only saved to enhance the usability of the app over time. Users of the Arrival Advisor app do so at their own discretion. The answers you provide will be used for the operation of this tool to provide you with guidance on resources and services that can help you adjust to life in Canada. Users cannot be identified by their answers to the questionnaire. The information is not used by Immigration, Refugees and Citizenship Canada for any other purpose and is not used for any immigration decision making."
 
-#: lib/components/questionnaire/questionnaire_component.js:107
+#: lib/components/questionnaire/questionnaire_component.js:111
 msgid "Back"
 msgstr "Back"
 
-#: lib/components/recommended_topics/call_to_action.js:99
+#: lib/components/recommended_topics/call_to_action.js:96
 msgid "Based on your answers, we recommend these topics for you:"
 msgstr "Based on your answers, we recommend these topics for you:"
 
@@ -74,17 +78,21 @@ msgstr "Bookmark the topics that you find helpful for future use."
 
 #: lib/components/error_screens/ErrorScreenSwitcherComponent.js:15
 msgid "Can't reach the internet"
-msgstr ""
+msgstr "Can't reach the internet"
 
-#: lib/components/help/help_component.js:125
+#: lib/components/help/help_component.js:131
 msgid "Cancel"
 msgstr "Cancel"
 
 #: lib/components/error_screens/ErrorScreenSwitcherComponent.js:19
 msgid "Check location services"
-msgstr ""
+msgstr "Check location services"
 
-#: lib/components/help/help_component.js:34
+#: lib/components/search/localized_place_holders.js:6
+msgid "City, address or postal code"
+msgstr "City, address or postal code"
+
+#: lib/components/help/help_component.js:40
 msgid "Contact Arrival Advisor team"
 msgstr "Contact Arrival Advisor team"
 
@@ -92,8 +100,8 @@ msgstr "Contact Arrival Advisor team"
 msgid "Created by"
 msgstr "Created by"
 
-#: lib/components/help/help_component.js:96
-#: lib/components/help/help_component.js:117
+#: lib/components/help/help_component.js:102
+#: lib/components/help/help_component.js:123
 msgid "Delete all user data"
 msgstr "Delete all user data"
 
@@ -102,11 +110,11 @@ msgstr "Delete all user data"
 msgid "Disclaimer"
 msgstr "Disclaimer"
 
-#: lib/components/help/help_component.js:119
+#: lib/components/help/help_component.js:125
 msgid "Do you want to delete all user data from this phone? This includes which answers are chosen in the questionnaire and which topics are bookmarked."
 msgstr "Do you want to delete all user data from this phone? This includes which answers are chosen in the questionnaire and which topics are bookmarked."
 
-#: lib/components/questionnaire/questionnaire_component.js:114
+#: lib/components/questionnaire/questionnaire_component.js:118
 msgid "Done"
 msgstr "Done"
 
@@ -114,27 +122,27 @@ msgstr "Done"
 msgid "EXPLORE TOPICS"
 msgstr "EXPLORE TOPICS"
 
-#: lib/components/services/service_list_item_component.js:65
-msgid "Email:"
-msgstr "Email:"
-
 #: lib/components/error_screens/ErrorScreenSwitcherComponent.js:17
 msgid "Enable location services"
-msgstr ""
+msgstr "Enable location services"
 
-#: lib/components/services/service_list_component.js:44
+#: lib/components/main/header_component.js:39
+msgid "FIND A SERVICE"
+msgstr "FIND A SERVICE"
+
+#: lib/components/services/service_list_component.js:58
 msgid "FIND A SERVICE NEAR YOU"
 msgstr "FIND A SERVICE NEAR YOU"
 
-#: lib/components/help/help_component.js:60
+#: lib/components/help/help_component.js:66
 msgid "FOR ADDITIONAL ASSISTANCE"
 msgstr "FOR ADDITIONAL ASSISTANCE"
 
-#: lib/components/help/help_component.js:72
+#: lib/components/help/help_component.js:78
 msgid "Find a settlement agency near me"
 msgstr "Find a settlement agency near me"
 
-#: lib/components/topics/task_detail_content_component.js:107
+#: lib/components/topics/task_detail_content_component.js:57
 msgid "Find related services near me"
 msgstr "Find related services near me"
 
@@ -146,15 +154,15 @@ msgstr "Find service providers near you that can help you through your settlemen
 msgid "From finding a job to learning English, accessing health care, and more, Arrival Advisor has everything you need to get started in your new community. Explore topics and services without ever needing to create an account. Access important information no matter where you are: the newcomer topics provided by Arrival Advisor are saved to your phone so you can view them, even without internet. You can fill out some questions to get personalized recommendations of topics and services to settle in British Columbia. Arrival Advisor is anonymous and your answers are only used to operate the app's recommendations. We never save or share your personal data with funders or any third parties."
 msgstr "From finding a job to learning English, accessing health care, and more, Arrival Advisor has everything you need to get started in your new community. Explore topics and services without ever needing to create an account. Access important information no matter where you are: the newcomer topics provided by Arrival Advisor are saved to your phone so you can view them, even without internet. You can fill out some questions to get personalized recommendations of topics and services to settle in British Columbia. Arrival Advisor is anonymous and your answers are only used to operate the app's recommendations. We never save or share your personal data with funders or any third parties."
 
-#: lib/components/recommended_topics/call_to_action.js:33
+#: lib/components/recommended_topics/call_to_action.js:30
 msgid "GETTING STARTED"
 msgstr "GETTING STARTED"
 
-#: lib/components/recommended_topics/call_to_action.js:36
+#: lib/components/recommended_topics/call_to_action.js:33
 msgid "Get information based on your needs"
 msgstr "Get information based on your needs"
 
-#: lib/components/recommended_topics/call_to_action.js:74
+#: lib/components/recommended_topics/call_to_action.js:71
 msgid "Go back to questions"
 msgstr "Go back to questions"
 
@@ -162,11 +170,11 @@ msgstr "Go back to questions"
 msgid "Go to Settings"
 msgstr "Go to Settings"
 
-#: lib/components/help/help_component.js:47
+#: lib/components/help/help_component.js:53
 msgid "Help & Support"
 msgstr "Help & Support"
 
-#: lib/components/help/help_component.js:50
+#: lib/components/help/help_component.js:56
 msgid "If you are having difficulty with settlement in Canada, we suggest getting in touch with a settlement worker."
 msgstr "If you are having difficulty with settlement in Canada, we suggest getting in touch with a settlement worker."
 
@@ -174,11 +182,11 @@ msgstr "If you are having difficulty with settlement in Canada, we suggest getti
 msgid "Information in this app is provided by the <0>Newcomers Guide to British Columbia</0> Copyright 2018 Province of British Columbia. All rights reserved."
 msgstr "Information in this app is provided by the <0>Newcomers Guide to British Columbia</0> Copyright 2018 Province of British Columbia. All rights reserved."
 
-#: lib/components/help/help_component.js:25
+#: lib/components/help/help_component.js:29
 msgid "Information on BC211"
 msgstr "Information on BC211"
 
-#: lib/components/help/help_component.js:20
+#: lib/components/help/help_component.js:22
 msgid "Information on HealthLinkBC (8-1-1)"
 msgstr "Information on HealthLinkBC (8-1-1)"
 
@@ -186,41 +194,54 @@ msgstr "Information on HealthLinkBC (8-1-1)"
 msgid "Information on emergency services (9-1-1)"
 msgstr "Information on emergency services (9-1-1)"
 
-#: lib/components/help/help_component.js:30
+#: lib/components/help/help_component.js:36
 msgid "Information on helplines"
 msgstr "Information on helplines"
 
 #: lib/components/error_screens/ErrorScreenSwitcherComponent.js:47
 msgid "It took too long finding your location."
-msgstr ""
+msgstr "It took too long finding your location."
 
 #: lib/components/error_screens/ErrorScreenSwitcherComponent.js:42
 msgid "It took too long finding your location. Setting your device's Location Services to “High Accuracy” can sometimes fix this problem."
-msgstr ""
+msgstr "It took too long finding your location. Setting your device's Location Services to “High Accuracy” can sometimes fix this problem."
+
+#: lib/components/content_verification/content_verification_component.js:7
+msgid "Last verified"
+msgstr "Last verified"
 
 #: lib/components/explore/explore_all_component.js:11
 msgid "Learn all about B.C."
 msgstr "Learn all about B.C."
 
-#: lib/components/help/help_component.js:21
+#: lib/components/help/help_component.js:24
 msgid "Mutlilingual health information services"
 msgstr "Mutlilingual health information services"
 
-#: lib/components/bookmarked_topics/bookmarked_topics_component.js:12
+#: lib/components/bookmarks/bookmarks_component.js:18
 msgid "My bookmarks"
 msgstr "My bookmarks"
 
-#: lib/components/questionnaire/questionnaire_component.js:97
+#: lib/components/search/location_input_modal.js:16
+msgid "My location"
+msgstr "My location"
+
+#: lib/components/search/search_term_and_location_component.js:27
+msgid "Near <0>My location</0>"
+msgstr "Near <0>My location</0>"
+
+#: lib/components/questionnaire/new_topics_modal_component.js:24
+msgid "New topics have been recommended based on your answers!"
+msgstr "New topics have been recommended based on your answers!"
+
+#: lib/components/questionnaire/questionnaire_component.js:101
 msgid "Next"
 msgstr "Next"
 
-#: lib/components/questionnaire/new_topics_modal_component.js:55
-msgid "No new topics recommended based on your answers."
-msgstr "No new topics recommended based on your answers."
-
+#: lib/components/bookmarks/service_bookmarks_component.js:9
 #: lib/components/services/service_list_component.js:24
 msgid "No services to show"
-msgstr ""
+msgstr "No services to show"
 
 #: lib/components/topics/task_list_component.js:69
 msgid "No topics to recommend"
@@ -230,23 +251,19 @@ msgstr "No topics to recommend"
 msgid "No topics to show"
 msgstr "No topics to show"
 
-#: lib/components/questionnaire/new_topics_modal_component.js:43
-msgid "Number of new topics recommended based on your answers:"
-msgstr "Number of new topics recommended based on your answers:"
-
-#: lib/components/questionnaire/questionnaire_component.js:75
+#: lib/components/questionnaire/questionnaire_component.js:79
 msgid "OF"
 msgstr "OF"
 
-#: lib/components/questionnaire/new_topics_modal_component.js:69
-msgid "OK"
-msgstr "OK"
+#: lib/components/organizations/organization_detail_component.js:49
+msgid "ORGANIZATION"
+msgstr "ORGANIZATION"
 
-#: lib/components/recommended_topics/call_to_action.js:60
+#: lib/components/recommended_topics/call_to_action.js:57
 msgid "Once you answer some questions, your recommendations will show up below. For now, here are some topics we recommend for everyone:"
 msgstr "Once you answer some questions, your recommendations will show up below. For now, here are some topics we recommend for everyone:"
 
-#: lib/components/maps_application_popup/maps_application_popup_component.js:10
+#: lib/components/maps_application_popup/maps_application_popup_component.js:9
 msgid "Open in maps"
 msgstr "Open in maps"
 
@@ -254,7 +271,7 @@ msgstr "Open in maps"
 msgid "PeaceGeeks is not liable for any damages incurred as a result of or related to the use of the app. PeaceGeeks is not an immigration consultancy network, and therefore cannot provide advice or support directly related to immigration. Arrival Advisor exists to offer newcomers a directory of services and resources to assist settlement in Metro Vancouver and does not exist in an official Immigration Service capacity."
 msgstr "PeaceGeeks is not liable for any damages incurred as a result of or related to the use of the app. PeaceGeeks is not an immigration consultancy network, and therefore cannot provide advice or support directly related to immigration. Arrival Advisor exists to offer newcomers a directory of services and resources to assist settlement in Metro Vancouver and does not exist in an official Immigration Service capacity."
 
-#: lib/components/help/help_component.js:16
+#: lib/components/help/help_component.js:17
 msgid "Police, fire and medical emergencies"
 msgstr "Police, fire and medical emergencies"
 
@@ -262,20 +279,25 @@ msgstr "Police, fire and medical emergencies"
 msgid "Privacy policy"
 msgstr "Privacy policy"
 
+#: lib/components/services/service_detail_component.js:35
+#: lib/components/services/service_list_item_component.js:31
+msgid "Provided by"
+msgstr "Provided by"
+
 #: lib/components/topics/task_detail_component.js:21
 msgid "RELATED TOPICS"
 msgstr "RELATED TOPICS"
 
-#: lib/components/expandable_content/expandable_content_component.js:77
+#: lib/components/expandable_content/expandable_content_component.js:83
 msgid "Read less"
 msgstr "Read less"
 
-#: lib/components/expandable_content/expandable_content_component.js:77
+#: lib/components/expandable_content/expandable_content_component.js:83
 msgid "Read more"
 msgstr "Read more"
 
 #: lib/components/recommended_topics/recommended_topics_component.js:38
-#: lib/components/topics/task_detail_content_component.js:62
+#: lib/components/topics/task_detail_content_component.js:35
 msgid "Recommended for you"
 msgstr "Recommended for you"
 
@@ -283,9 +305,21 @@ msgstr "Recommended for you"
 msgid "SELECT YOUR LANGUAGE"
 msgstr "SELECT YOUR LANGUAGE"
 
-#: lib/components/bookmarked_topics/bookmarked_topics_component.js:15
-msgid "Save important topics to build your personal plan for settlement."
-msgstr "Save important topics to build your personal plan for settlement."
+#: lib/components/services/service_detail_component.js:23
+msgid "SERVICE"
+msgstr "SERVICE"
+
+#: lib/components/bookmarks/bookmarks_component.js:21
+msgid "Save important topics and services to build your personal plan for settlement."
+msgstr "Save important topics and services to build your personal plan for settlement."
+
+#: lib/components/search/localized_place_holders.js:5
+msgid "Search for services"
+msgstr "Search for services"
+
+#: lib/components/questionnaire/new_topics_modal_component.js:39
+msgid "See recommendations"
+msgstr "See recommendations"
 
 #: lib/components/welcome/welcome_component.js:38
 msgid "Select your language"
@@ -293,17 +327,22 @@ msgstr "Select your language"
 
 #: lib/components/error_screens/ErrorScreenSwitcherComponent.js:22
 msgid "Server error"
-msgstr ""
+msgstr "Server error"
 
 #: lib/components/about/about_component.js:60
 msgid "Server version:"
 msgstr "Server version:"
 
+#: lib/components/bookmarks/bookmarks_component.js:56
+#: lib/components/organizations/organization_detail_component.js:40
+msgid "Services"
+msgstr "Services"
+
 #: lib/components/error_screens/ErrorScreenSwitcherComponent.js:31
 msgid "Services are not available offline. Please connect to the internet and try again."
-msgstr ""
+msgstr "Services are not available offline. Please connect to the internet and try again."
 
-#: lib/components/help/help_component.js:26
+#: lib/components/help/help_component.js:31
 msgid "Services information and referral"
 msgstr "Services information and referral"
 
@@ -311,7 +350,7 @@ msgstr "Services information and referral"
 msgid "Settling in Canada is now easier."
 msgstr "Settling in Canada is now easier."
 
-#: lib/components/questionnaire/questionnaire_component.js:97
+#: lib/components/questionnaire/questionnaire_component.js:101
 msgid "Skip"
 msgstr "Skip"
 
@@ -342,20 +381,24 @@ msgstr "This is Arrival Advisor version:"
 
 #: lib/components/error_screens/ErrorScreenSwitcherComponent.js:36
 msgid "To find services, please turn on Location Services for Arrival Advisor in Settings and try again."
-msgstr ""
+msgstr "To find services, please turn on Location Services for Arrival Advisor in Settings and try again."
+
+#: lib/components/bookmarks/bookmarks_component.js:53
+msgid "Topics"
+msgstr "Topics"
 
 #: lib/components/error_screens/ErrorScreenComponent.js:53
 msgid "Try again"
-msgstr ""
+msgstr "Try again"
 
-#: lib/components/recommended_topics/call_to_action.js:70
+#: lib/components/recommended_topics/call_to_action.js:67
 msgid "UPDATE MY RECOMMENDATIONS"
 msgstr "UPDATE MY RECOMMENDATIONS"
 
-#: lib/components/services/service_list_item_component.js:57
-msgid "Web:"
-msgstr "Web:"
+#: lib/components/website/website_component.js:13
+msgid "Website"
+msgstr "Website"
 
 #: lib/components/error_screens/ErrorScreenSwitcherComponent.js:50
 msgid "We’re having difficulty connecting to the server. Please try again later."
-msgstr ""
+msgstr "We’re having difficulty connecting to the server. Please try again later."


### PR DESCRIPTION
Retrieved new jsx strings and cleaned deprecated strings by doing the following: 

`cd pathways-frontend`
`yarn extract-strings-clean`

Move generated messages.po file to `ui-strings/jsx_strings` and rename to `jsx_strings.pot`
